### PR TITLE
🔓 raise game history cap from 50 to 200

### DIFF
--- a/internal/prediction/recorder.go
+++ b/internal/prediction/recorder.go
@@ -71,8 +71,8 @@ type PredictionHistory struct {
 
 func (h *PredictionHistory) Add(pred PredictionRecord) {
 	h.Predictions = append(h.Predictions, pred)
-	if len(h.Predictions) > 50 {
-		h.Predictions = h.Predictions[len(h.Predictions)-50:]
+	if len(h.Predictions) > 200 {
+		h.Predictions = h.Predictions[len(h.Predictions)-200:]
 	}
 }
 

--- a/internal/prediction/recorder_test.go
+++ b/internal/prediction/recorder_test.go
@@ -163,7 +163,7 @@ func TestPredictionHistory_Add(t *testing.T) {
 
 func TestPredictionHistory_AddLimit(t *testing.T) {
 	h := &PredictionHistory{
-		Predictions: make([]PredictionRecord, 50),
+		Predictions: make([]PredictionRecord, 200),
 		Current:    DefaultWeights(),
 	}
 
@@ -173,8 +173,8 @@ func TestPredictionHistory_AddLimit(t *testing.T) {
 
 	h.Add(PredictionRecord{Date: "2026-04-50"})
 
-	if len(h.Predictions) > 50 {
-		t.Errorf("should cap at 50: %d", len(h.Predictions))
+	if len(h.Predictions) > 200 {
+		t.Errorf("should cap at 200: %d", len(h.Predictions))
 	}
 }
 


### PR DESCRIPTION
The prediction history was capped at 50 games, causing old games to be silently dropped after ~45 entries. An MLB season is 162 games, so this raises the cap to 200 to cover the full season plus off days and postponed games.