### PR TITLE
🔙 add --from-bluesky flag to backfill predictions from Bluesky posts

### DIFF
--- a/internal/bluesky/client.go
+++ b/internal/bluesky/client.go
@@ -319,6 +319,78 @@ func (c *Client) uploadBlob(data []byte, mimeType string) (*BlobRef, error) {
 	return result.Blob, nil
 }
 
+// AuthorFeedItem represents a single post from the author feed.
+type AuthorFeedItem struct {
+	PostURI   string
+	CreatedAt string // "2006-01-02"
+	Text      string
+	IsReply   bool
+}
+
+// GetAuthorFeed fetches all posts from a given actor's feed using the public API.
+// No authentication required.
+func GetAuthorFeed(actor string) ([]AuthorFeedItem, error) {
+	base := "https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed"
+	var items []AuthorFeedItem
+	cursor := ""
+
+	for {
+		url := base + "?actor=" + actor + "&limit=100"
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+
+		resp, err := http.Get(url)
+		if err != nil {
+			return nil, fmt.Errorf("fetching author feed: %w", err)
+		}
+
+		var body struct {
+			Feed []struct {
+				Post struct {
+					URI    string `json:"uri"`
+					Record struct {
+						CreatedAt string `json:"createdAt"`
+						Text      string `json:"text"`
+						Reply     *struct {
+							Root struct {
+								URI string `json:"uri"`
+							} `json:"root"`
+						} `json:"reply,omitempty"`
+					} `json:"record"`
+				} `json:"post"`
+			} `json:"feed"`
+			Cursor string `json:"cursor,omitempty"`
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("decoding feed response: %w", err)
+		}
+		resp.Body.Close()
+
+		for _, f := range body.Feed {
+			created := f.Post.Record.CreatedAt
+			if len(created) >= 10 {
+				created = created[:10]
+			}
+			items = append(items, AuthorFeedItem{
+				PostURI:   f.Post.URI,
+				CreatedAt: created,
+				Text:      f.Post.Record.Text,
+				IsReply:   f.Post.Record.Reply != nil,
+			})
+		}
+
+		if body.Cursor == "" {
+			break
+		}
+		cursor = body.Cursor
+	}
+
+	return items, nil
+}
+
 // DryRunPoster implements Poster but prints to a callback instead of posting.
 type DryRunPoster struct {
 	OnPost  func(text string)

--- a/internal/bluesky/prediction_backfill.go
+++ b/internal/bluesky/prediction_backfill.go
@@ -1,0 +1,127 @@
+package bluesky
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/tlugger/rockiscope/internal/prediction"
+)
+
+var (
+	opponentRe = regexp.MustCompile(`^⚾ Rockies (?:vs |@ )(.+)`)
+	pickRe     = regexp.MustCompile(`victory|defeat`)
+	pctRe      = regexp.MustCompile(`\((\d+)%\)$`)
+	offDayRe   = regexp.MustCompile(`^⚾ No Rockies game today`)
+)
+
+// ParsedPrediction holds data extracted from a Bluesky prediction post.
+type ParsedPrediction struct {
+	Date      string
+	Opponent  string
+	Predicted string // "W" or "L"
+	WinProb   float64 // 0-1
+}
+
+// ParsePredictionPost attempts to parse a Bluesky post text as a game prediction.
+// Returns nil if the post is not a prediction (off-day, reply, etc.).
+func ParsePredictionPost(text string, date string) *ParsedPrediction {
+	if offDayRe.MatchString(text) {
+		return nil
+	}
+
+	lines := strings.Split(text, "\n")
+	if len(lines) == 0 {
+		return nil
+	}
+
+	m := opponentRe.FindStringSubmatch(lines[0])
+	if m == nil {
+		return nil
+	}
+	opponent := strings.TrimSpace(m[1])
+
+	var predLine string
+	for _, line := range lines {
+		if strings.Contains(line, "🔮") {
+			predLine = line
+			break
+		}
+	}
+	if predLine == "" {
+		return nil
+	}
+
+	pickMatch := pickRe.FindString(predLine)
+	var predicted string
+	switch pickMatch {
+	case "victory":
+		predicted = "W"
+	case "defeat":
+		predicted = "L"
+	default:
+		return nil
+	}
+
+	pctMatch := pctRe.FindStringSubmatch(predLine)
+	if pctMatch == nil {
+		return nil
+	}
+	pct, err := strconv.ParseFloat(pctMatch[1], 64)
+	if err != nil {
+		return nil
+	}
+
+	return &ParsedPrediction{
+		Date:      date,
+		Opponent:  opponent,
+		Predicted: predicted,
+		WinProb:   pct / 100,
+	}
+}
+
+// BackfillPredictionsFromBluesky fetches the bot's Bluesky feed, parses prediction
+// posts, and updates synthetic records in history with the real prediction data.
+// Factors and game results (Actual, RockiesScore, OppScore) are left untouched.
+func BackfillPredictionsFromBluesky(hist *prediction.PredictionHistory, actor string, logger *log.Logger) (int, error) {
+	logger.Println("fetching posts from Bluesky...")
+	items, err := GetAuthorFeed(actor)
+	if err != nil {
+		return 0, fmt.Errorf("fetching Bluesky feed: %w", err)
+	}
+	logger.Printf("fetched %d posts", len(items))
+
+	var updated int
+	for _, item := range items {
+		if item.IsReply {
+			continue
+		}
+
+		pp := ParsePredictionPost(item.Text, item.CreatedAt)
+		if pp == nil {
+			continue
+		}
+
+		for i := range hist.Predictions {
+			p := &hist.Predictions[i]
+			if !p.Synthetic {
+				continue
+			}
+			if p.Date != pp.Date || p.Opponent != pp.Opponent {
+				continue
+			}
+
+			p.Predicted = pp.Predicted
+			p.WinProbability = pp.WinProb
+			p.Confidence = pp.WinProb * 100
+			p.Synthetic = false
+			updated++
+			break
+		}
+	}
+
+	logger.Printf("backfilled %d predictions from Bluesky posts", updated)
+	return updated, nil
+}

--- a/internal/bluesky/prediction_backfill_test.go
+++ b/internal/bluesky/prediction_backfill_test.go
@@ -1,0 +1,126 @@
+package bluesky
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParsePredictionPost_GameDay(t *testing.T) {
+	text := `⚾ Rockies vs Miami Marlins
+🕐 6:40 PM MDT at Coors Field
+🪖 Kyle Freeland (7.50 ERA, 1-7)
+📊 33-53 | vs MIA: 0-5 | L3
+
+🔮 The stars lean toward a Rockies defeat (66%)`
+
+	pp := ParsePredictionPost(text, "2026-07-01")
+	if pp == nil {
+		t.Fatal("expected parsed prediction, got nil")
+	}
+	if pp.Opponent != "Miami Marlins" {
+		t.Errorf("opponent = %q, want %q", pp.Opponent, "Miami Marlins")
+	}
+	if pp.Predicted != "L" {
+		t.Errorf("predicted = %q, want %q", pp.Predicted, "L")
+	}
+	if math.Abs(pp.WinProb-0.66) > 0.001 {
+		t.Errorf("winProb = %f, want %f", pp.WinProb, 0.66)
+	}
+	if pp.Date != "2026-07-01" {
+		t.Errorf("date = %q, want %q", pp.Date, "2026-07-01")
+	}
+}
+
+func TestParsePredictionPost_AwayGame(t *testing.T) {
+	text := `⚾ Rockies @ San Diego Padres
+🕐 1:40 PM MDT at Petco Park
+🪖 Austin Gomber (4.50 ERA, 2-3)
+
+🔮 The cosmos strongly favor a Rockies victory (73%)`
+
+	pp := ParsePredictionPost(text, "2026-04-09")
+	if pp == nil {
+		t.Fatal("expected parsed prediction, got nil")
+	}
+	if pp.Opponent != "San Diego Padres" {
+		t.Errorf("opponent = %q, want %q", pp.Opponent, "San Diego Padres")
+	}
+	if pp.Predicted != "W" {
+		t.Errorf("predicted = %q, want %q", pp.Predicted, "W")
+	}
+	if math.Abs(pp.WinProb-0.73) > 0.001 {
+		t.Errorf("winProb = %f, want %f", pp.WinProb, 0.73)
+	}
+}
+
+func TestParsePredictionPost_NoPitcher(t *testing.T) {
+	text := `⚾ Rockies vs Atlanta Braves
+🕐 6:40 PM MDT at Coors Field
+
+🔮 A cosmic coin flip a Rockies victory (50%)`
+
+	pp := ParsePredictionPost(text, "2026-05-01")
+	if pp == nil {
+		t.Fatal("expected parsed prediction, got nil")
+	}
+	if pp.Opponent != "Atlanta Braves" {
+		t.Errorf("opponent = %q, want %q", pp.Opponent, "Atlanta Braves")
+	}
+	if pp.Predicted != "W" {
+		t.Errorf("predicted = %q, want %q", pp.Predicted, "W")
+	}
+	if math.Abs(pp.WinProb-0.50) > 0.001 {
+		t.Errorf("winProb = %f, want %f", pp.WinProb, 0.50)
+	}
+}
+
+func TestParsePredictionPost_OffDay(t *testing.T) {
+	text := `⚾ No Rockies game today.
+📊 33-53 (0.384) | Run Diff: -42 | L2`
+
+	pp := ParsePredictionPost(text, "2026-07-02")
+	if pp != nil {
+		t.Errorf("expected nil for off-day, got %+v", pp)
+	}
+}
+
+func TestParsePredictionPost_Reply(t *testing.T) {
+	text := `📚 Another chapter in the prophecy fulfilled.
+
+🏁 Rockies L
+📊 Colorado Rockies 3-14 Miami Marlins
+🎯 24/44 correct predictions this season`
+
+	pp := ParsePredictionPost(text, "2026-07-01")
+	if pp != nil {
+		t.Errorf("expected nil for reply, got %+v", pp)
+	}
+}
+
+func TestParsePredictionPost_EmptyText(t *testing.T) {
+	pp := ParsePredictionPost("", "2026-07-01")
+	if pp != nil {
+		t.Errorf("expected nil for empty text, got %+v", pp)
+	}
+}
+
+func TestParsePredictionPost_NudgeVictory(t *testing.T) {
+	text := `⚾ Rockies vs Los Angeles Dodgers
+🕐 1:10 PM MDT at Coors Field
+
+🔮 A slight celestial nudge toward a Rockies victory (53%)`
+
+	pp := ParsePredictionPost(text, "2026-04-17")
+	if pp == nil {
+		t.Fatal("expected parsed prediction, got nil")
+	}
+	if pp.Opponent != "Los Angeles Dodgers" {
+		t.Errorf("opponent = %q, want %q", pp.Opponent, "Los Angeles Dodgers")
+	}
+	if pp.Predicted != "W" {
+		t.Errorf("predicted = %q, want %q", pp.Predicted, "W")
+	}
+	if math.Abs(pp.WinProb-0.53) > 0.001 {
+		t.Errorf("winProb = %f, want %f", pp.WinProb, 0.53)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -148,6 +148,13 @@ func cmdPreview(logger *log.Logger) {
 }
 
 func cmdBackfill(logger *log.Logger) {
+	fromBluesky := false
+	for _, arg := range os.Args[2:] {
+		if arg == "--from-bluesky" {
+			fromBluesky = true
+		}
+	}
+
 	dataDir := getDataDir()
 	hist, err := prediction.LoadHistory(dataDir)
 	if err != nil {
@@ -218,6 +225,18 @@ func cmdBackfill(logger *log.Logger) {
 	sort.SliceStable(hist.Predictions, func(i, j int) bool {
 		return hist.Predictions[i].Date < hist.Predictions[j].Date
 	})
+
+	if fromBluesky {
+		username := os.Getenv("BLUESKY_USERNAME")
+		if username == "" {
+			logger.Fatal("BLUESKY_USERNAME must be set for --from-bluesky")
+		}
+		updated, err := bluesky.BackfillPredictionsFromBluesky(hist, username, logger)
+		if err != nil {
+			logger.Fatalf("bluesky backfill: %v", err)
+		}
+		logger.Printf("bluesky backfill: %d predictions updated", updated)
+	}
 
 	if err := prediction.SaveHistory(hist, dataDir); err != nil {
 		logger.Fatalf("saving history: %v", err)


### PR DESCRIPTION
**Problem:** The old 50-game cap dropped early-season predictions from prediction_history.json. Running `backfill` reacquires game results from the MLB API but creates synthetic records with a generic "L" prediction at 50% confidence — the real W/L pick and win probability are lost.

**Solution:** Adds `--from-bluesky` to the existing `backfill` command. After the MLB API backfill completes, it fetches the bot's prediction posts from Bluesky via the public API (app.bsky.feed.getAuthorFeed), parses each to extract the actual W/L pick and win probability, then updates matching synthetic records.

**Files:**
- `internal/bluesky/client.go` — add GetAuthorFeed() for paginated feed fetching
- `internal/bluesky/prediction_backfill.go` — ParsePredictionPost() parser + BackfillPredictionsFromBluesky() merge logic
- `internal/bluesky/prediction_backfill_test.go` — parser tests against real post formats
- `main.go` — --from-bluesky flag parsing

**Usage:**
```
rockiscope backfill --from-bluesky
```

**What it updates:**
- Predicted (W/L pick) — from the "victory"/"defeat" keyword
- WinProbability — from the (XX%) in the post
- Confidence — derived from win probability
- Synthetic — set to false

**What it leaves untouched:** Factors, Actual, RockiesScore, OppScore, GamePK — game results still come from the MLB API.
