### PR TITLE
🗓️ fix doubleheader and postponed game handling

### DIFF
--- a/internal/bluesky/backfill_feed_test.go
+++ b/internal/bluesky/backfill_feed_test.go
@@ -1,0 +1,194 @@
+package bluesky
+
+import (
+	"math"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/tlugger/rockiscope/internal/mlb"
+	"github.com/tlugger/rockiscope/internal/prediction"
+)
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	tt, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", s, err)
+	}
+	return tt
+}
+
+func predPost(uri, createdAt, text string) AuthorFeedItem {
+	return AuthorFeedItem{
+		PostURI:      uri,
+		CreatedAt:    createdAt[:10],
+		CreatedAtRaw: createdAt,
+		Text:         text,
+	}
+}
+
+func gameText(vsAt, opponent, pick string, pct int) string {
+	verb := "victory"
+	if pick == "L" {
+		verb = "defeat"
+	}
+	return "⚾ Rockies " + vsAt + " " + opponent +
+		"\n🕐 6:40 PM MDT at Coors Field\n\n🔮 The stars lean toward a Rockies " + verb + " (" + strconv.Itoa(pct) + "%)"
+}
+
+func findByPk(hist *prediction.PredictionHistory, pk int) *prediction.PredictionRecord {
+	for i := range hist.Predictions {
+		if hist.Predictions[i].GamePK == pk {
+			return &hist.Predictions[i]
+		}
+	}
+	return nil
+}
+
+// End-to-end backfill over two real-world shapes at once:
+//   - date drift: a post whose UTC timestamp is the day after the official date
+//   - split double-header: two posts one day, one before each game, distinct pks
+func TestBackfillFromFeed_HandlesDriftAndDoubleHeader(t *testing.T) {
+	games := []mlb.GameResult{
+		// Away night game: official date 04-09, first pitch rolls to 04-10 UTC.
+		{GamePk: 823319, Date: "2026-04-09", GameDateTime: mustTime(t, "2026-04-10T01:40:00Z"), Opponent: "San Diego Padres", IsHome: false, RockiesScore: 3, OppScore: 7, Won: false},
+		// Split double-header 05-07: game 1 at 1:10 PM MDT, game 2 at 6:40 PM MDT
+		// (official date 05-07 for both; game 2's first pitch rolls to 05-08 UTC).
+		{GamePk: 824361, Date: "2026-05-07", GameDateTime: mustTime(t, "2026-05-07T19:10:00Z"), Opponent: "New York Mets", IsHome: true, GameNumber: 1, RockiesScore: 5, OppScore: 10, Won: false},
+		{GamePk: 824362, Date: "2026-05-07", GameDateTime: mustTime(t, "2026-05-08T00:40:00Z"), Opponent: "New York Mets", IsHome: true, GameNumber: 2, RockiesScore: 6, OppScore: 2, Won: true},
+	}
+
+	items := []AuthorFeedItem{
+		// Padres: posted ~1h before first pitch, UTC date is 04-10 (drift).
+		predPost("at://padres", "2026-04-10T00:40:00Z", gameText("@", "San Diego Padres", "L", 60)),
+		// DH game 1 post (~1h before 1:10 PM game).
+		predPost("at://mets1", "2026-05-07T18:10:00Z", gameText("vs", "New York Mets", "L", 61)),
+		// DH game 2 post (~1h before 6:40 PM game).
+		predPost("at://mets2", "2026-05-07T23:40:00Z", gameText("vs", "New York Mets", "W", 55)),
+		// A reply (follow-up) that must be ignored.
+		{PostURI: "at://reply", CreatedAt: "2026-05-07", CreatedAtRaw: "2026-05-07T22:00:00Z", Text: "🌙 Planets aligned.", IsReply: true},
+	}
+
+	hist := &prediction.PredictionHistory{Current: prediction.Weights{WinRate: 1}}
+	n := backfillFromFeed(hist, items, games, testLogger())
+
+	if n != 3 {
+		t.Fatalf("expected 3 predictions backfilled, got %d", n)
+	}
+	if len(hist.Predictions) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(hist.Predictions))
+	}
+
+	padres := findByPk(hist, 823319)
+	if padres == nil {
+		t.Fatal("padres record missing")
+	}
+	if padres.Date != "2026-04-09" {
+		t.Errorf("padres date = %q, want official 2026-04-09 (drift corrected)", padres.Date)
+	}
+	if padres.Predicted != "L" || math.Abs(padres.WinProbability-0.40) > 0.001 {
+		t.Errorf("padres pred=%q winProb=%f, want L / 0.40 (defeat 60%%)", padres.Predicted, padres.WinProbability)
+	}
+
+	g1 := findByPk(hist, 824361)
+	g2 := findByPk(hist, 824362)
+	if g1 == nil || g2 == nil {
+		t.Fatal("double-header records missing")
+	}
+	if g1.PostURI != "at://mets1" || g1.Predicted != "L" || g1.GameNumber != 1 {
+		t.Errorf("DH game 1 wrong: uri=%q pred=%q gn=%d", g1.PostURI, g1.Predicted, g1.GameNumber)
+	}
+	if g2.PostURI != "at://mets2" || g2.Predicted != "W" || g2.GameNumber != 2 {
+		t.Errorf("DH game 2 wrong: uri=%q pred=%q gn=%d", g2.PostURI, g2.Predicted, g2.GameNumber)
+	}
+	// Game 2's UTC first pitch is 05-08, but the record uses the official date.
+	if g2.Date != "2026-05-07" {
+		t.Errorf("DH game 2 date = %q, want official 2026-05-07", g2.Date)
+	}
+}
+
+// When two posts resolve to the same game (a re-post after a postponement), the
+// post closest to first pitch wins and no duplicate record is created.
+func TestBackfillFromFeed_DedupesRepostByNearestFirstPitch(t *testing.T) {
+	games := []mlb.GameResult{
+		{GamePk: 824362, Date: "2026-05-07", GameDateTime: mustTime(t, "2026-05-07T19:10:00Z"), Opponent: "New York Mets", IsHome: true, RockiesScore: 6, OppScore: 2, Won: true},
+	}
+	items := []AuthorFeedItem{
+		// Makeup-day post ~1h before first pitch — should win.
+		predPost("at://makeup", "2026-05-07T18:14:00Z", gameText("vs", "New York Mets", "L", 61)),
+		// Earlier same-day post also resolves to this game but is farther away.
+		predPost("at://early", "2026-05-07T06:00:00Z", gameText("vs", "New York Mets", "W", 55)),
+	}
+
+	hist := &prediction.PredictionHistory{Current: prediction.Weights{WinRate: 1}}
+	n := backfillFromFeed(hist, items, games, testLogger())
+
+	if n != 1 || len(hist.Predictions) != 1 {
+		t.Fatalf("expected 1 deduped record, got n=%d len=%d", n, len(hist.Predictions))
+	}
+	rec := hist.Predictions[0]
+	if rec.PostURI != "at://makeup" || rec.Predicted != "L" {
+		t.Errorf("expected nearest-first-pitch post to win, got uri=%q pred=%q", rec.PostURI, rec.Predicted)
+	}
+}
+
+// Backfill upserts onto an existing record (e.g. a synthetic one) by gamePk
+// rather than appending a duplicate, and clears the synthetic flag.
+func TestBackfillFromFeed_UpsertsExistingByGamePk(t *testing.T) {
+	games := []mlb.GameResult{
+		{GamePk: 824210, Date: "2026-04-14", GameDateTime: mustTime(t, "2026-04-15T01:40:00Z"), Opponent: "Houston Astros", IsHome: false, RockiesScore: 6, OppScore: 7, Won: false},
+	}
+	hist := &prediction.PredictionHistory{
+		Predictions: []prediction.PredictionRecord{
+			{Date: "2026-04-15", Opponent: "Houston Astros", Predicted: "L", GamePK: 824210, Synthetic: true, Actual: "L", RockiesScore: 6, OppScore: 7, WinProbability: 0.5, Confidence: 50},
+		},
+		Current: prediction.Weights{WinRate: 1},
+	}
+	items := []AuthorFeedItem{
+		predPost("at://houston", "2026-04-15T00:40:00Z", gameText("@", "Houston Astros", "L", 58)),
+	}
+
+	n := backfillFromFeed(hist, items, games, testLogger())
+	if n != 1 {
+		t.Fatalf("expected 1 update, got %d", n)
+	}
+	if len(hist.Predictions) != 1 {
+		t.Fatalf("expected upsert (no new record), got %d records", len(hist.Predictions))
+	}
+	rec := hist.Predictions[0]
+	if rec.Synthetic {
+		t.Error("synthetic flag should be cleared after backfill")
+	}
+	if rec.PostURI != "at://houston" {
+		t.Errorf("PostURI = %q, want at://houston", rec.PostURI)
+	}
+	if rec.Date != "2026-04-14" {
+		t.Errorf("Date = %q, want official 2026-04-14 (drift corrected)", rec.Date)
+	}
+	// winProb corrected to P(win) = 1 - 0.58, and the pre-existing result kept.
+	if math.Abs(rec.WinProbability-0.42) > 0.001 {
+		t.Errorf("winProb = %f, want 0.42", rec.WinProbability)
+	}
+	if rec.Actual != "L" {
+		t.Errorf("existing result should be preserved, got actual=%q", rec.Actual)
+	}
+}
+
+// A post with no game inside the match window is skipped, not force-matched.
+func TestBackfillFromFeed_SkipsWhenNoGameInWindow(t *testing.T) {
+	games := []mlb.GameResult{
+		{GamePk: 1, Date: "2026-06-01", GameDateTime: mustTime(t, "2026-06-01T20:00:00Z"), Opponent: "Los Angeles Angels", IsHome: false, Won: true},
+	}
+	items := []AuthorFeedItem{
+		// Different opponent -> no match.
+		predPost("at://x", "2026-06-01T19:00:00Z", gameText("@", "Seattle Mariners", "L", 55)),
+	}
+	hist := &prediction.PredictionHistory{Current: prediction.Weights{WinRate: 1}}
+	if n := backfillFromFeed(hist, items, games, testLogger()); n != 0 {
+		t.Errorf("expected 0 backfilled, got %d", n)
+	}
+	if len(hist.Predictions) != 0 {
+		t.Errorf("expected no records created, got %d", len(hist.Predictions))
+	}
+}

--- a/internal/bluesky/client.go
+++ b/internal/bluesky/client.go
@@ -321,10 +321,11 @@ func (c *Client) uploadBlob(data []byte, mimeType string) (*BlobRef, error) {
 
 // AuthorFeedItem represents a single post from the author feed.
 type AuthorFeedItem struct {
-	PostURI   string
-	CreatedAt string // "2006-01-02"
-	Text      string
-	IsReply   bool
+	PostURI     string
+	CreatedAt   string // date only, "2006-01-02"
+	CreatedAtRaw string // full RFC3339 timestamp as returned by Bluesky
+	Text        string
+	IsReply     bool
 }
 
 // GetAuthorFeed fetches all posts from a given actor's feed using the public API.
@@ -370,15 +371,17 @@ func GetAuthorFeed(actor string) ([]AuthorFeedItem, error) {
 		resp.Body.Close()
 
 		for _, f := range body.Feed {
-			created := f.Post.Record.CreatedAt
+			raw := f.Post.Record.CreatedAt
+			created := raw
 			if len(created) >= 10 {
 				created = created[:10]
 			}
 			items = append(items, AuthorFeedItem{
-				PostURI:   f.Post.URI,
-				CreatedAt: created,
-				Text:      f.Post.Record.Text,
-				IsReply:   f.Post.Record.Reply != nil,
+				PostURI:      f.Post.URI,
+				CreatedAt:    created,
+				CreatedAtRaw: raw,
+				Text:         f.Post.Record.Text,
+				IsReply:      f.Post.Record.Reply != nil,
 			})
 		}
 

--- a/internal/bluesky/prediction_backfill.go
+++ b/internal/bluesky/prediction_backfill.go
@@ -3,10 +3,13 @@ package bluesky
 import (
 	"fmt"
 	"log"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/tlugger/rockiscope/internal/mlb"
 	"github.com/tlugger/rockiscope/internal/prediction"
 )
 
@@ -17,12 +20,18 @@ var (
 	offDayRe   = regexp.MustCompile(`^⚾ No Rockies game today`)
 )
 
+// matchWindow bounds how far a prediction post's timestamp may sit from a game's
+// first pitch to be considered the same game. Posts go up ~1h before first pitch;
+// the generous window also lets a prediction posted the day before a postponed
+// game bind to its next-day makeup, while still excluding the following series.
+const matchWindow = 30 * time.Hour
+
 // ParsedPrediction holds data extracted from a Bluesky prediction post.
 type ParsedPrediction struct {
 	Date      string
 	Opponent  string
-	Predicted string // "W" or "L"
-	WinProb   float64 // 0-1
+	Predicted string  // "W" or "L"
+	WinProb   float64 // P(Rockies win), 0-1
 }
 
 // ParsePredictionPost attempts to parse a Bluesky post text as a game prediction.
@@ -74,54 +83,133 @@ func ParsePredictionPost(text string, date string) *ParsedPrediction {
 		return nil
 	}
 
+	// The post shows the probability of the PREDICTED outcome. WinProbability is
+	// always P(Rockies win): for a victory pick that is the shown %, but for a
+	// defeat pick it is the complement. (The old code stored the defeat % as the
+	// win probability, inverting every "L" record.)
+	winProb := pct / 100
+	if predicted == "L" {
+		winProb = 1 - pct/100
+	}
+
 	return &ParsedPrediction{
 		Date:      date,
 		Opponent:  opponent,
 		Predicted: predicted,
-		WinProb:   pct / 100,
+		WinProb:   winProb,
 	}
 }
 
-// BackfillPredictionsFromBluesky fetches the bot's Bluesky feed, parses prediction
-// posts, and updates synthetic records in history with the real prediction data.
-// Factors and game results (Actual, RockiesScore, OppScore) are left untouched.
-func BackfillPredictionsFromBluesky(hist *prediction.PredictionHistory, actor string, logger *log.Logger) (int, error) {
+// nearestGame returns the game most likely referenced by a prediction post: the
+// same-opponent game whose first pitch is closest to the post time, within
+// matchWindow. The absolute distance to first pitch is returned for dedup.
+func nearestGame(opponent string, postTime time.Time, games []mlb.GameResult) (*mlb.GameResult, time.Duration) {
+	var best *mlb.GameResult
+	bestDelta := time.Duration(math.MaxInt64)
+	for i := range games {
+		g := &games[i]
+		if g.Opponent != opponent || g.GameDateTime.IsZero() {
+			continue
+		}
+		delta := g.GameDateTime.Sub(postTime)
+		if delta < 0 {
+			delta = -delta
+		}
+		if delta <= matchWindow && delta < bestDelta {
+			best, bestDelta = g, delta
+		}
+	}
+	return best, bestDelta
+}
+
+// BackfillPredictionsFromBluesky fetches the bot's Bluesky feed, resolves each
+// prediction post to its MLB game by first-pitch time, and upserts the record
+// keyed on gamePk. This correctly handles double-headers (two games one date)
+// and postponements (a prediction that lands on a makeup on another day). When
+// two posts resolve to the same game (a re-post of a postponed prediction), the
+// post nearest to first pitch wins. Game results already present on records are
+// left untouched.
+//
+// Limitation: matching is purely by first-pitch time, so a prediction posted a
+// day or more before a game that is later made up as game 2 of a *straight*
+// double-header (whose two games share a near-identical placeholder start time)
+// can be ambiguous. The live path avoids this entirely by recording gamePk at
+// post time; this backfill is a recovery tool for reconstructing lost history.
+func BackfillPredictionsFromBluesky(hist *prediction.PredictionHistory, actor string, games []mlb.GameResult, logger *log.Logger) (int, error) {
 	logger.Println("fetching posts from Bluesky...")
 	items, err := GetAuthorFeed(actor)
 	if err != nil {
 		return 0, fmt.Errorf("fetching Bluesky feed: %w", err)
 	}
 	logger.Printf("fetched %d posts", len(items))
+	return backfillFromFeed(hist, items, games, logger), nil
+}
 
-	var updated int
+// backfillFromFeed is the testable core of the Bluesky backfill: it takes already
+// fetched feed items rather than reaching out to the network.
+func backfillFromFeed(hist *prediction.PredictionHistory, items []AuthorFeedItem, games []mlb.GameResult, logger *log.Logger) int {
+	// Resolve every prediction post to a game, keeping the closest post per game.
+	type match struct {
+		pp      *ParsedPrediction
+		game    *mlb.GameResult
+		postURI string
+		delta   time.Duration
+	}
+	byGame := make(map[int]match)
 	for _, item := range items {
 		if item.IsReply {
 			continue
 		}
-
 		pp := ParsePredictionPost(item.Text, item.CreatedAt)
 		if pp == nil {
 			continue
 		}
-
-		for i := range hist.Predictions {
-			p := &hist.Predictions[i]
-			if !p.Synthetic {
-				continue
-			}
-			if p.Date != pp.Date || p.Opponent != pp.Opponent {
-				continue
-			}
-
-			p.Predicted = pp.Predicted
-			p.WinProbability = pp.WinProb
-			p.Confidence = pp.WinProb * 100
-			p.Synthetic = false
-			updated++
-			break
+		postTime, err := time.Parse(time.RFC3339, item.CreatedAtRaw)
+		if err != nil {
+			logger.Printf("skipping post with unparseable timestamp %q", item.CreatedAtRaw)
+			continue
+		}
+		g, delta := nearestGame(pp.Opponent, postTime, games)
+		if g == nil {
+			logger.Printf("no MLB game within window for %s post vs %s (%s)", pp.Date, pp.Opponent, item.PostURI)
+			continue
+		}
+		if prev, ok := byGame[g.GamePk]; !ok || delta < prev.delta {
+			byGame[g.GamePk] = match{pp: pp, game: g, postURI: item.PostURI, delta: delta}
 		}
 	}
 
+	// Index existing records by gamePk for upsert.
+	byGamePk := make(map[int]*prediction.PredictionRecord)
+	for i := range hist.Predictions {
+		p := &hist.Predictions[i]
+		if p.GamePK != 0 {
+			byGamePk[p.GamePK] = p
+		}
+	}
+
+	var updated int
+	for pk, m := range byGame {
+		g := m.game
+		rec := byGamePk[pk]
+		if rec == nil {
+			hist.Predictions = append(hist.Predictions, prediction.PredictionRecord{GamePK: pk})
+			rec = &hist.Predictions[len(hist.Predictions)-1]
+			byGamePk[pk] = rec
+		}
+
+		rec.Date = g.Date
+		rec.Opponent = g.Opponent
+		rec.IsHome = g.IsHome
+		rec.GameNumber = g.GameNumber
+		rec.Predicted = m.pp.Predicted
+		rec.WinProbability = m.pp.WinProb
+		rec.Confidence = m.pp.WinProb * 100
+		rec.PostURI = m.postURI
+		rec.Synthetic = false
+		updated++
+	}
+
 	logger.Printf("backfilled %d predictions from Bluesky posts", updated)
-	return updated, nil
+	return updated
 }

--- a/internal/bluesky/prediction_backfill_test.go
+++ b/internal/bluesky/prediction_backfill_test.go
@@ -23,8 +23,10 @@ func TestParsePredictionPost_GameDay(t *testing.T) {
 	if pp.Predicted != "L" {
 		t.Errorf("predicted = %q, want %q", pp.Predicted, "L")
 	}
-	if math.Abs(pp.WinProb-0.66) > 0.001 {
-		t.Errorf("winProb = %f, want %f", pp.WinProb, 0.66)
+	// The post shows the defeat probability (66%); WinProbability is P(Rockies
+	// win) = 1 - 0.66 = 0.34.
+	if math.Abs(pp.WinProb-0.34) > 0.001 {
+		t.Errorf("winProb = %f, want %f", pp.WinProb, 0.34)
 	}
 	if pp.Date != "2026-07-01" {
 		t.Errorf("date = %q, want %q", pp.Date, "2026-07-01")

--- a/internal/mlb/client.go
+++ b/internal/mlb/client.go
@@ -74,7 +74,8 @@ func (c *Client) GetHeadToHead(opponentID int) (*H2HRecord, error) {
 
 type GameResult struct {
 	GamePk       int    `json:"gamePk"`
-	Date        string `json:"date"`
+	Date        string `json:"date"` // MLB official date "2006-01-02"
+	GameDateTime time.Time `json:"gameDateTime"` // first-pitch time (UTC)
 	OpponentID  int    `json:"opponentId"`
 	Opponent    string `json:"opponent"`
 	IsHome      bool   `json:"isHome"`
@@ -82,6 +83,7 @@ type GameResult struct {
 	OppScore    int    `json:"oppScore"`
 	Won         bool   `json:"won"`
 	Status     string `json:"status"`
+	GameNumber  int    `json:"gameNumber,omitempty"`
 }
 
 func (c *Client) GetGameLiveStatus(date string) ([]GameLiveStatus, error) {
@@ -134,6 +136,13 @@ func (c *Client) parseGameResults(resp scheduleResponse) []GameResult {
 			if g.Status.AbstractGameState != "Final" {
 				continue
 			}
+			// A postponed/cancelled slot can carry abstractGameState "Final" with a
+			// 0-0 score; skip it so it isn't mistaken for a real result. The played
+			// makeup appears as its own (usually same-gamePk) Final listing.
+			switch g.Status.DetailedState {
+			case "Postponed", "Cancelled", "Canceled":
+				continue
+			}
 
 			gameTime, err := time.Parse(time.RFC3339Nano, g.GameDate)
 			if err != nil {
@@ -143,9 +152,16 @@ func (c *Client) parseGameResults(resp scheduleResponse) []GameResult {
 				}
 			}
 
+			officialDate := g.OfficialDate
+			if officialDate == "" {
+				officialDate = gameTime.Format("2006-01-02")
+			}
+
 			var gr GameResult
 			gr.GamePk = g.GamePk
-			gr.Date = gameTime.Format("2006-01-02")
+			gr.Date = officialDate
+			gr.GameDateTime = gameTime
+			gr.GameNumber = g.GameNumber
 			gr.Status = g.Status.AbstractGameState
 
 			if g.Teams.Away.Team.ID == c.teamID {
@@ -239,12 +255,19 @@ func (c *Client) parseGame(g scheduleGame) (*Game, error) {
 
 	isHome := g.Teams.Home.Team.ID == c.teamID
 
+	officialDate := g.OfficialDate
+	if officialDate == "" {
+		officialDate = gameTime.Format("2006-01-02")
+	}
+
 	game := &Game{
 		GamePk:        g.GamePk,
 		GameDateTime:  gameTime,
+		OfficialDate:  officialDate,
 		Status:        g.Status.AbstractGameState,
 		DetailedState: g.Status.DetailedState,
 		Reason:        g.Status.Reason,
+		RescheduleGameDate: g.RescheduleGameDate,
 		Venue:         g.Venue.Name,
 		IsHome:        isHome,
 		GameNumber:    g.GameNumber,
@@ -476,6 +499,8 @@ type scheduleResponse struct {
 type scheduleGame struct {
 	GamePk     int    `json:"gamePk"`
 	GameDate   string `json:"gameDate"`
+	OfficialDate string `json:"officialDate"`
+	RescheduleGameDate string `json:"rescheduleGameDate"`
 	GameNumber int    `json:"gameNumber"`
 	DoubleHeader string `json:"doubleheader"`
 	Status     struct {

--- a/internal/mlb/officialdate_test.go
+++ b/internal/mlb/officialdate_test.go
@@ -1,0 +1,103 @@
+package mlb
+
+import "testing"
+
+// makeScheduleGame builds a minimal scheduleGame with the Rockies away vs opp.
+func rockiesAwayGame(pk int, gameDate, officialDate string, awayScore, homeScore int, abstract, detailed string) scheduleGame {
+	var g scheduleGame
+	g.GamePk = pk
+	g.GameDate = gameDate
+	g.OfficialDate = officialDate
+	g.Status.AbstractGameState = abstract
+	g.Status.DetailedState = detailed
+	g.Teams.Away.Team.ID = RockiesID
+	g.Teams.Away.Team.Name = "Colorado Rockies"
+	g.Teams.Away.Score = awayScore
+	g.Teams.Home.Team.ID = 135
+	g.Teams.Home.Team.Name = "San Diego Padres"
+	g.Teams.Home.Score = homeScore
+	return g
+}
+
+func TestParseGame_OfficialDateRescheduleAndGameNumber(t *testing.T) {
+	c := &Client{teamID: RockiesID}
+
+	g := rockiesAwayGame(823319, "2026-04-10T01:40:00Z", "2026-04-09", 3, 7, "Final", "Final")
+	g.GameNumber = 2
+	g.DoubleHeader = "S"
+	g.RescheduleGameDate = "2026-04-09"
+
+	game, err := c.parseGame(g)
+	if err != nil {
+		t.Fatalf("parseGame: %v", err)
+	}
+	// The UTC gameDate is 2026-04-10, but the official (local) date is 2026-04-09.
+	if game.OfficialDate != "2026-04-09" {
+		t.Errorf("OfficialDate = %q, want 2026-04-09", game.OfficialDate)
+	}
+	if game.GameNumber != 2 {
+		t.Errorf("GameNumber = %d, want 2", game.GameNumber)
+	}
+	if game.DoubleHeader != "S" {
+		t.Errorf("DoubleHeader = %q, want S", game.DoubleHeader)
+	}
+	if game.RescheduleGameDate != "2026-04-09" {
+		t.Errorf("RescheduleGameDate = %q, want 2026-04-09", game.RescheduleGameDate)
+	}
+	if game.IsHome {
+		t.Error("IsHome = true, want false (Rockies away)")
+	}
+}
+
+func TestParseGame_OfficialDateFallsBackToGameDate(t *testing.T) {
+	c := &Client{teamID: RockiesID}
+	g := rockiesAwayGame(1, "2026-05-01T18:10:00Z", "", 0, 0, "Preview", "Scheduled")
+
+	game, err := c.parseGame(g)
+	if err != nil {
+		t.Fatalf("parseGame: %v", err)
+	}
+	if game.OfficialDate != "2026-05-01" {
+		t.Errorf("OfficialDate = %q, want fallback 2026-05-01", game.OfficialDate)
+	}
+}
+
+func TestParseGameResults_UsesOfficialDateAndSkipsPostponed(t *testing.T) {
+	c := &Client{teamID: RockiesID}
+
+	var resp scheduleResponse
+	resp.Dates = []struct {
+		Games []scheduleGame `json:"games"`
+	}{
+		{
+			Games: []scheduleGame{
+				// Real Final game: UTC date rolls to 04-10, official date is 04-09.
+				rockiesAwayGame(823319, "2026-04-10T01:40:00Z", "2026-04-09", 3, 7, "Final", "Final"),
+				// Postponed slot: abstractGameState "Final" but detailedState "Postponed",
+				// carries a bogus 0-0 score. Must be skipped.
+				rockiesAwayGame(824362, "2026-05-06T00:40:00Z", "2026-05-07", 0, 0, "Final", "Postponed"),
+			},
+		},
+	}
+
+	results := c.parseGameResults(resp)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (postponed skipped), got %d", len(results))
+	}
+	gr := results[0]
+	if gr.GamePk != 823319 {
+		t.Errorf("GamePk = %d, want 823319", gr.GamePk)
+	}
+	if gr.Date != "2026-04-09" {
+		t.Errorf("Date = %q, want official date 2026-04-09", gr.Date)
+	}
+	if gr.GameDateTime.IsZero() {
+		t.Error("GameDateTime should be populated")
+	}
+	if gr.Opponent != "San Diego Padres" || gr.IsHome {
+		t.Errorf("opponent/home wrong: %q home=%v", gr.Opponent, gr.IsHome)
+	}
+	if gr.RockiesScore != 3 || gr.OppScore != 7 || gr.Won {
+		t.Errorf("score/won wrong: %d-%d won=%v", gr.RockiesScore, gr.OppScore, gr.Won)
+	}
+}

--- a/internal/mlb/types.go
+++ b/internal/mlb/types.go
@@ -6,9 +6,11 @@ import "time"
 type Game struct {
 	GamePk        int
 	GameDateTime  time.Time
+	OfficialDate  string // MLB's canonical game date "2006-01-02"; authoritative over the wall clock
 	Status        string // "Preview", "Live", "Final" (abstractGameState)
 	DetailedState string // "Scheduled", "Postponed", "Cancelled", etc.
 	Reason        string // reason for postponement/cancellation
+	RescheduleGameDate string // official date a postponed game was moved to, if any
 	HomeTeam      TeamInfo
 	AwayTeam      TeamInfo
 	Venue         string

--- a/internal/prediction/gamenumber_test.go
+++ b/internal/prediction/gamenumber_test.go
@@ -1,0 +1,37 @@
+package prediction
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// GameNumber must round-trip through JSON and be omitted when zero (single games),
+// so double-header records stay distinguishable without bloating every entry.
+func TestPredictionRecord_GameNumberJSON(t *testing.T) {
+	dh := PredictionRecord{
+		Date: "2026-04-26", Opponent: "New York Mets", Predicted: "W",
+		GamePK: 823637, GameNumber: 2, WinProbability: 0.53, Confidence: 53,
+	}
+	data, err := json.Marshal(dh)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"gameNumber":2`) {
+		t.Errorf("expected gameNumber in JSON, got %s", data)
+	}
+
+	var back PredictionRecord
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.GameNumber != 2 {
+		t.Errorf("GameNumber round-trip = %d, want 2", back.GameNumber)
+	}
+
+	single := PredictionRecord{Date: "2026-04-24", Opponent: "New York Mets", GamePK: 823638}
+	data, _ = json.Marshal(single)
+	if strings.Contains(string(data), "gameNumber") {
+		t.Errorf("gameNumber should be omitted when zero, got %s", data)
+	}
+}

--- a/internal/prediction/recorder.go
+++ b/internal/prediction/recorder.go
@@ -60,6 +60,7 @@ type PredictionRecord struct {
 	Synthetic    bool         `json:"synthetic,omitempty"` // backfilled pre-bot record; excluded from prediction-accuracy stats
 	PostURI       string        `json:"postUri,omitempty"`
 	GamePK       int          `json:"gamePk,omitempty"`
+	GameNumber   int          `json:"gameNumber,omitempty"` // 1 or 2 for double-headers
 	Factors      FactorScores  `json:"factors"`
 	WinProbability float64    `json:"winProbability"`
 }

--- a/internal/scheduler/doubleheader_test.go
+++ b/internal/scheduler/doubleheader_test.go
@@ -1,0 +1,113 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/tlugger/rockiscope/internal/mlb"
+	"github.com/tlugger/rockiscope/internal/prediction"
+)
+
+// homeGame builds a Rockies home game vs the given opponent.
+func homeGame(pk, gameNumber int, officialDate, opponent string) *mlb.Game {
+	return &mlb.Game{
+		GamePk:       pk,
+		OfficialDate: officialDate,
+		GameNumber:   gameNumber,
+		IsHome:       true,
+		HomeTeam:     mlb.TeamInfo{ID: mlb.RockiesID, Name: "Colorado Rockies"},
+		AwayTeam:     mlb.TeamInfo{ID: 121, Name: opponent},
+	}
+}
+
+// recordPrediction must stamp the record with MLB's official date (not the wall
+// clock) and carry the double-header game number.
+func TestRecordPrediction_UsesOfficialDateAndGameNumber(t *testing.T) {
+	s := &Scheduler{
+		logger:      testLogger(),
+		dataDir:     "",
+		predHistory: &prediction.PredictionHistory{Current: prediction.Weights{WinRate: 1}},
+	}
+
+	game := homeGame(823637, 2, "2026-04-26", "New York Mets")
+	pred := prediction.Prediction{WinProbability: 0.53, Pick: "W"}
+
+	// Pass a WRONG wall-clock date; the record should use the official date.
+	s.recordPrediction("2026-04-25", game, pred, "at://post/1")
+
+	if len(s.predHistory.Predictions) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(s.predHistory.Predictions))
+	}
+	rec := s.predHistory.Predictions[0]
+	if rec.Date != "2026-04-26" {
+		t.Errorf("Date = %q, want official 2026-04-26", rec.Date)
+	}
+	if rec.GameNumber != 2 {
+		t.Errorf("GameNumber = %d, want 2", rec.GameNumber)
+	}
+	if rec.GamePK != 823637 {
+		t.Errorf("GamePK = %d, want 823637", rec.GamePK)
+	}
+}
+
+// A double-header's two games share date+opponent but have distinct gamePks.
+// Each result must settle its own record, not the first one it sees.
+func TestProcessCompletedGame_DoubleHeaderSettlesByGamePk(t *testing.T) {
+	poster := &mockPoster{}
+	s := &Scheduler{
+		poster:  poster,
+		logger:  testLogger(),
+		dataDir: "",
+		predHistory: &prediction.PredictionHistory{
+			Predictions: []prediction.PredictionRecord{
+				{Date: "2026-04-26", Opponent: "New York Mets", Predicted: "L", GamePK: 823635, GameNumber: 1, PostURI: "at://g1"},
+				{Date: "2026-04-26", Opponent: "New York Mets", Predicted: "W", GamePK: 823637, GameNumber: 2, PostURI: "at://g2"},
+			},
+			Current: prediction.Weights{WinRate: 1},
+		},
+	}
+
+	// Game 2 finalizes first; it must settle record #2, not #1.
+	s.processCompletedGame(mlb.GameResult{GamePk: 823637, Date: "2026-04-26", Opponent: "New York Mets", RockiesScore: 3, OppScore: 0, Won: true}, "2026-04-26")
+	s.processCompletedGame(mlb.GameResult{GamePk: 823635, Date: "2026-04-26", Opponent: "New York Mets", RockiesScore: 3, OppScore: 1, Won: true}, "2026-04-26")
+
+	g1 := s.predHistory.Predictions[0]
+	g2 := s.predHistory.Predictions[1]
+	if g1.Actual != "W" || g1.RockiesScore != 3 || g1.OppScore != 1 {
+		t.Errorf("game 1 settled wrong: actual=%s %d-%d", g1.Actual, g1.RockiesScore, g1.OppScore)
+	}
+	if g2.Actual != "W" || g2.RockiesScore != 3 || g2.OppScore != 0 {
+		t.Errorf("game 2 settled wrong: actual=%s %d-%d", g2.Actual, g2.RockiesScore, g2.OppScore)
+	}
+}
+
+// A prediction posted before a postponement should settle when the makeup plays,
+// and the record's date should be corrected to the day it was actually played.
+func TestProcessCompletedGame_PostponementRedatesRecord(t *testing.T) {
+	poster := &mockPoster{}
+	s := &Scheduler{
+		poster:  poster,
+		logger:  testLogger(),
+		dataDir: "",
+		predHistory: &prediction.PredictionHistory{
+			Predictions: []prediction.PredictionRecord{
+				// Predicted for the originally scheduled 5/05 date.
+				{Date: "2026-05-05", Opponent: "New York Mets", Predicted: "L", GamePK: 824362, PostURI: "at://p"},
+			},
+			Current: prediction.Weights{WinRate: 1},
+		},
+	}
+
+	// Makeup played 5/07 (same gamePk, new official date), Rockies won.
+	s.processCompletedGame(mlb.GameResult{GamePk: 824362, Date: "2026-05-07", Opponent: "New York Mets", RockiesScore: 6, OppScore: 2, Won: true}, "2026-05-07")
+
+	rec := s.predHistory.Predictions[0]
+	if rec.Actual != "W" {
+		t.Errorf("actual = %q, want W", rec.Actual)
+	}
+	if rec.Date != "2026-05-07" {
+		t.Errorf("Date = %q, want re-dated 2026-05-07", rec.Date)
+	}
+	if len(poster.replies) != 1 {
+		t.Errorf("expected 1 follow-up reply, got %d", len(poster.replies))
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -577,14 +577,22 @@ func (s *Scheduler) recordPrediction(date string, game *mlb.Game, pred predictio
 			factors.Stars = v
 		}
 	}
+	// Prefer MLB's official date over the wall-clock date: it is stable across
+	// time zones and correctly dates double-header game 2 and postponed makeups.
+	recordDate := game.OfficialDate
+	if recordDate == "" {
+		recordDate = date
+	}
+
 	rec := prediction.PredictionRecord{
-		Date:            date,
+		Date:            recordDate,
 		Opponent:        game.Opponent().Name,
 		IsHome:          game.IsHome,
 		Predicted:       pred.Pick,
 		Confidence:     pred.WinProbability * 100,
 		PostURI:         postURI,
 		GamePK:          game.GamePk,
+		GameNumber:      game.GameNumber,
 		WinProbability: pred.WinProbability,
 		Factors:       factors,
 	}
@@ -687,7 +695,15 @@ func (s *Scheduler) processCompletedGame(gr mlb.GameResult, today string) bool {
 		if p.Actual != "" {
 			continue
 		}
-		if p.GamePK == gr.GamePk || (p.Date == gr.Date && p.Opponent == gr.Opponent) {
+		// Match strictly on gamePk. A date+opponent fallback mis-settles
+		// double-headers (two games share a date+opponent) and never matches a
+		// postponed makeup (its date differs from the original prediction).
+		if gr.GamePk != 0 && p.GamePK == gr.GamePk {
+			// Re-date to the official date in case this game was postponed and
+			// made up on a different day than originally predicted.
+			if gr.Date != "" {
+				p.Date = gr.Date
+			}
 			actual := "L"
 			if gr.Won {
 				actual = "W"

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -393,7 +393,7 @@ func TestCheckForCompletedGames_MatchingResults(t *testing.T) {
 	}
 }
 
-func TestCheckForCompletedGames_MatchesByDateAndOpponent(t *testing.T) {
+func TestCheckForCompletedGames_MatchesByGamePk(t *testing.T) {
 	denver := mlb.DenverLocation()
 	nowTime := time.Date(2026, 4, 8, 14, 0, 0, 0, denver)
 	poster := &mockPoster{}
@@ -401,7 +401,7 @@ func TestCheckForCompletedGames_MatchesByDateAndOpponent(t *testing.T) {
 	s := &Scheduler{
 		mlb: &mockMLB{
 			gamesSince: []mlb.GameResult{
-				{GamePk: 0, Date: "2026-04-08", Opponent: "Houston Astros", Won: true}, // GamePK not set, tests fallback
+				{GamePk: 778901, Date: "2026-04-08", Opponent: "Houston Astros", Won: true},
 			},
 		},
 		poster:    poster,
@@ -411,7 +411,7 @@ func TestCheckForCompletedGames_MatchesByDateAndOpponent(t *testing.T) {
 		dataDir:   "",
 		predHistory: &prediction.PredictionHistory{
 			Predictions: []prediction.PredictionRecord{
-				{Date: "2026-04-08", Opponent: "Houston Astros", Predicted: "W", GamePK: 0}, // no GamePK
+				{Date: "2026-04-08", Opponent: "Houston Astros", Predicted: "W", GamePK: 778901},
 			},
 			Current: prediction.Weights{WinRate: 0.30, Pitcher: 0.30},
 		},
@@ -428,6 +428,45 @@ func TestCheckForCompletedGames_MatchesByDateAndOpponent(t *testing.T) {
 
 	if len(poster.replies) != 1 {
 		t.Fatalf("expected 1 reply, got %d", len(poster.replies))
+	}
+}
+
+// A record without a gamePk must NOT be settled by a date+opponent guess. That
+// fallback mis-attributed double-header results and never matched postponed
+// makeups; results now bind only on gamePk.
+func TestCheckForCompletedGames_NoDateOpponentFallback(t *testing.T) {
+	denver := mlb.DenverLocation()
+	nowTime := time.Date(2026, 4, 8, 14, 0, 0, 0, denver)
+	poster := &mockPoster{}
+
+	s := &Scheduler{
+		mlb: &mockMLB{
+			gamesSince: []mlb.GameResult{
+				{GamePk: 778901, Date: "2026-04-08", Opponent: "Houston Astros", Won: true},
+			},
+		},
+		poster:  poster,
+		now:     func() time.Time { return nowTime },
+		sleep:   func(d time.Duration) {},
+		logger:  testLogger(),
+		dataDir: "",
+		predHistory: &prediction.PredictionHistory{
+			Predictions: []prediction.PredictionRecord{
+				{Date: "2026-04-08", Opponent: "Houston Astros", Predicted: "W", GamePK: 0},
+			},
+			Current: prediction.Weights{WinRate: 0.30, Pitcher: 0.30},
+		},
+	}
+
+	if err := s.checkForCompletedGames(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := s.predHistory.Predictions[0].Actual; got != "" {
+		t.Errorf("expected record to stay unsettled (no gamePk), got actual = %q", got)
+	}
+	if len(poster.replies) != 0 {
+		t.Errorf("expected no replies, got %d", len(poster.replies))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -231,7 +231,7 @@ func cmdBackfill(logger *log.Logger) {
 		if username == "" {
 			logger.Fatal("BLUESKY_USERNAME must be set for --from-bluesky")
 		}
-		updated, err := bluesky.BackfillPredictionsFromBluesky(hist, username, logger)
+		updated, err := bluesky.BackfillPredictionsFromBluesky(hist, username, results, logger)
 		if err != nil {
 			logger.Fatalf("bluesky backfill: %v", err)
 		}


### PR DESCRIPTION
## Why

Prediction records were dated by the **wall clock at post time** and results were settled with a `date + opponent` fallback. That combination misbehaves exactly where MLB scheduling gets weird:

- **Date drift** — evening/away games posted after midnight UTC landed a day late.
- **Doubleheaders** — two games share a date+opponent, so the fallback could attach the first final's score to the wrong prediction.
- **Postponements** — a makeup plays on a different date than originally predicted, so the fallback never matched it, and the record kept the wrong date.

This is the same class of bug that required a manual rebuild of `prediction_history.json`. This patch fixes the handler so it doesn't recur.

## What changed

**Live handler**
- Record predictions with MLB's `officialDate` (stable across time zones; correctly dates DH game 2 and postponed makeups) instead of the local post date.
- Settle results **strictly by `gamePk`**; drop the `date + opponent` fallback.
- **Re-date** a record to its official date when a postponed game is made up on another day.
- Persist `gameNumber` to disambiguate doubleheader games.

**MLB layer**
- Parse `officialDate` / `rescheduleGameDate` into `Game` and `GameResult`; `GameResult` now carries `GameDateTime` and `GameNumber`.
- `parseGameResults` skips **postponed/cancelled** slots, which can carry a bogus `0-0` `Final` score.

**Backfill (`--from-bluesky`)**
- Fix the `winProbability` **inversion** for "L" picks (the post shows the *defeat* %, so `winProb = 1 - pct`).
- Resolve each post to its game by **nearest first pitch → gamePk** and upsert by gamePk (handles date drift + doubleheaders), deduping a re-posted (postponed) prediction to the post closest to first pitch. Known limitation documented in code for the day-before-a-straight-DH-game-2 case.

## Tests

Coverage added for every change:
- `mlb`: officialDate + reschedule + gameNumber parsing; official-date usage and postponed-slot skipping in `parseGameResults`.
- `prediction`: `gameNumber` JSON round-trip + omitempty.
- `scheduler`: `recordPrediction` uses official date + gameNumber; doubleheader settles by gamePk; postponement re-dates the record; no date+opponent fallback.
- `bluesky`: winProbability inversion; end-to-end backfill over drift + doubleheader; re-post dedup; upsert-by-gamePk; skip-when-no-game-in-window.

`go build`, `go vet`, and the full suite pass; total coverage 65% (CI threshold 50%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)